### PR TITLE
feat: make ember power select more accessible 

### DIFF
--- a/addon/components/power-select-multiple/input.hbs
+++ b/addon/components/power-select-multiple/input.hbs
@@ -4,14 +4,15 @@
   class="ember-power-select-trigger-multiple-input"
   aria-activedescendant={{if @select.isOpen @ariaActiveDescendant}}
   aria-haspopup="listbox"
-  aria-expanded={{if @select.isOpen "true" "false"}}
-  autocomplete="off"
+  aria-expanded="{{if @select.isOpen 'true' 'false'}}"
+  autocomplete="list"
   autocorrect="off"
   autocapitalize="off"
   spellcheck={{false}}
   id="ember-power-select-trigger-multiple-input-{{@select.uniqueId}}"
   aria-labelledby={{@ariaLabelledBy}}
   aria-label={{@ariaLabel}}
+  aria-autocomplete="list"
   value={{@select.searchText}}
   aria-controls={{if @select.isOpen @listboxId}}
   style={{this.triggerMultipleInputStyle}}

--- a/addon/components/power-select-multiple/input.hbs
+++ b/addon/components/power-select-multiple/input.hbs
@@ -5,7 +5,7 @@
   aria-activedescendant={{if @select.isOpen @ariaActiveDescendant}}
   aria-haspopup="listbox"
   aria-expanded="{{if @select.isOpen 'true' 'false'}}"
-  autocomplete="list"
+  autocomplete="off"
   autocorrect="off"
   autocapitalize="off"
   spellcheck={{false}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -6,7 +6,7 @@
   @preventScroll={{or @preventScroll false}}
   @onClose={{this.handleClose}}
   @onOpen={{this.handleOpen}}
-  @onFocus{{this.onFocusTrigger dropdown}}
+  @onFocus{{fn this.onFocusTrigger dropdown}}
   @renderInPlace={{@renderInPlace}}
   @verticalPosition={{@verticalPosition}}
   @disabled={{@disabled}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -174,6 +174,8 @@
             @highlightOnHover={{this.highlightOnHover}}
             @groupComponent={{Group}}
             id={{listboxId}}
+            @ariaLabel={{@ariaLabel}}
+            @ariaLabelledBy={{@ariaLabelledBy}}
             class="ember-power-select-options" as |option select|>
             {{yield option select}}
           </Options>

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -6,7 +6,7 @@
   @preventScroll={{or @preventScroll false}}
   @onClose={{this.handleClose}}
   @onOpen={{this.handleOpen}}
-  @onFocus{{fn this.onFocusTrigger dropdown}}
+  @onFocus{{this.onFocusTrigger}}
   @renderInPlace={{@renderInPlace}}
   @verticalPosition={{@verticalPosition}}
   @disabled={{@disabled}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -176,7 +176,7 @@
             id={{listboxId}}
             @ariaLabel={{@ariaLabel}}
             @ariaLabelledBy={{@ariaLabelledBy}}
-            @ariaSelected="{{ember-power-select-is-selected opt @selected}}"
+            @ariaSelected={{ember-power-select-is-selected opt @selected}}
             class="ember-power-select-options" as |option select|>
             {{yield option select}}
           </Options>

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -6,7 +6,6 @@
   @preventScroll={{or @preventScroll false}}
   @onClose={{this.handleClose}}
   @onOpen={{this.handleOpen}}
-  @onFocus{{this.onFocusTrigger}}
   @renderInPlace={{@renderInPlace}}
   @verticalPosition={{@verticalPosition}}
   @disabled={{@disabled}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -176,6 +176,7 @@
             id={{listboxId}}
             @ariaLabel={{@ariaLabel}}
             @ariaLabelledBy={{@ariaLabelledBy}}
+            @ariaSelected="{{ember-power-select-is-selected opt @selected}}"
             class="ember-power-select-options" as |option select|>
             {{yield option select}}
           </Options>

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -6,6 +6,7 @@
   @preventScroll={{or @preventScroll false}}
   @onClose={{this.handleClose}}
   @onOpen={{this.handleOpen}}
+  @onFocus{{this.onFocusTrigger dropdown}}
   @renderInPlace={{@renderInPlace}}
   @verticalPosition={{@verticalPosition}}
   @disabled={{@disabled}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -36,6 +36,7 @@
       {{did-update this._performSearch this.searchText}}
       {{on "keydown" this.handleTriggerKeydown}}
       {{on "focus" this.handleFocus}}
+      {{on "focusin" this._open}}
       {{on "blur" this.handleBlur}}
       class="ember-power-select-trigger {{@triggerClass}}{{if publicAPI.isActive " ember-power-select-trigger--active"}}"
       aria-activedescendant={{if dropdown.isOpen (unless @searchEnabled (concat publicAPI.uniqueId "-" this.highlightedIndex))}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -147,8 +147,8 @@
             @noMatchesMessage={{this.noMatchesMessage}}
             @select={{publicAPI}}
             id={{listboxId}}
-            aria-label={{@ariaLabel}}
-            aria-labelledby={{@ariaLabelledBy}}
+            @ariaLabel={{@ariaLabel}}
+            @ariaLabelledBy={{@ariaLabelledBy}}
           />
         {{/let}}
       {{else}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -53,12 +53,12 @@
       tabindex={{and (not @disabled) (or @tabindex "0")}}
       ...attributes
     >
-      {{#let 
-        (if 
-          @triggerComponent 
-          (component (ensure-safe-component @triggerComponent)) 
+      {{#let
+        (if
+          @triggerComponent
+          (component (ensure-safe-component @triggerComponent))
           (component 'power-select/trigger')
-        ) 
+        )
       as |Trigger|}}
         <Trigger
           @allowClear={{@allowClear}}
@@ -75,9 +75,9 @@
           @onInput={{this.handleInput}}
           @onKeydown={{this.handleKeydown}}
           @placeholder={{@placeholder}}
-          @placeholderComponent={{if 
-            @placeholderComponent 
-            (ensure-safe-component @placeholderComponent) 
+          @placeholderComponent={{if
+            @placeholderComponent
+            (ensure-safe-component @placeholderComponent)
             (component 'power-select/placeholder')
           }}
           @ariaActiveDescendant={{concat publicAPI.uniqueId "-" this.highlightedIndex}}
@@ -93,12 +93,12 @@
       @animationEnabled={{@animationEnabled}}
     >
       {{#if (not-eq @beforeOptionsComponent null)}}
-        {{#let 
-          (if 
-            @beforeOptionsComponent 
+        {{#let
+          (if
+            @beforeOptionsComponent
             (component (ensure-safe-component @beforeOptionsComponent))
             (component 'power-select/before-options')
-          ) 
+          )
         as |BeforeOptions|}}
           <BeforeOptions
             @select={{publicAPI}}
@@ -120,49 +120,49 @@
         {{/let}}
       {{/if}}
       {{#if this.mustShowSearchMessage}}
-        {{#let 
-          (if 
-            @searchMessageComponent 
+        {{#let
+          (if
+            @searchMessageComponent
             (component (ensure-safe-component @searchMessageComponent))
             (component 'power-select/search-message')
-          ) 
+          )
         as |SearchMessage|}}
-          <SearchMessage 
+          <SearchMessage
             @searchMessage={{this.searchMessage}}
             @select={{publicAPI}}
-            id={{listboxId}} 
-            aria-label={{@ariaLabel}}
-            aria-labelledby={{@ariaLabelledBy}} 
-          /> 
+            id={{listboxId}}
+            @ariaLabel={{@ariaLabel}}
+            @ariaLabelledBy={{@ariaLabelledBy}}
+          />
         {{/let}}
       {{else if this.mustShowNoMessages}}
-        {{#let 
-          (if 
+        {{#let
+          (if
             @noMatchesMessageComponent
             (component (ensure-safe-component @noMatchesMessageComponent))
             (component 'power-select/no-matches-message')
-          ) 
+          )
          as |NoMatchesMessage|}}
-          <NoMatchesMessage 
-            @noMatchesMessage={{this.noMatchesMessage}} 
-            @select={{publicAPI}} 
-            id={{listboxId}} 
+          <NoMatchesMessage
+            @noMatchesMessage={{this.noMatchesMessage}}
+            @select={{publicAPI}}
+            id={{listboxId}}
             aria-label={{@ariaLabel}}
-            aria-labelledby={{@ariaLabelledBy}} 
+            aria-labelledby={{@ariaLabelledBy}}
           />
         {{/let}}
       {{else}}
-        {{#let 
-          (if 
+        {{#let
+          (if
             @optionsComponent
             (component (ensure-safe-component @optionsComponent))
             (component 'power-select/options')
-          ) 
-          (if 
+          )
+          (if
             @groupComponent
             (component (ensure-safe-component @groupComponent))
             (component 'power-select/power-select-group')
-          ) 
+          )
         as |Options Group|}}
           <Options
             @loadingMessage={{or @loadingMessage "Loading options..."}}
@@ -179,7 +179,7 @@
           </Options>
         {{/let}}
       {{/if}}
-      
+
       {{#if @afterOptionsComponent}}
         {{#let (component (ensure-safe-component @afterOptionsComponent)) as |AfterOptions|}}
           <AfterOptions

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -36,8 +36,6 @@
       {{did-update this._performSearch this.searchText}}
       {{on "keydown" this.handleTriggerKeydown}}
       {{on "focus" this.handleFocus}}
-      {{on "mousedown" this.handleMousedown}}
-      {{on "focusin" this._open}}
       {{on "blur" this.handleBlur}}
       class="ember-power-select-trigger {{@triggerClass}}{{if publicAPI.isActive " ember-power-select-trigger--active"}}"
       aria-activedescendant={{if dropdown.isOpen (unless @searchEnabled (concat publicAPI.uniqueId "-" this.highlightedIndex))}}

--- a/addon/components/power-select.hbs
+++ b/addon/components/power-select.hbs
@@ -36,6 +36,7 @@
       {{did-update this._performSearch this.searchText}}
       {{on "keydown" this.handleTriggerKeydown}}
       {{on "focus" this.handleFocus}}
+      {{on "mousedown" this.handleMousedown}}
       {{on "focusin" this._open}}
       {{on "blur" this.handleBlur}}
       class="ember-power-select-trigger {{@triggerClass}}{{if publicAPI.isActive " ember-power-select-trigger--active"}}"

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -294,11 +294,12 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     console.log('target gaining focuswithin', event.target);
     console.log('target losing focuswithin', event.relatedTarget);
     console.log('activeElement', document.activeElement);
-    const triggerElement = document.getElementById(this.args.triggerId);
-    if (triggerElement?.contains(document.activeElement))  {
-      console.log('skipping _open, triggerElement contains activeElement');
-      return;
-    }
+    console.log('isActive', this.storedAPI.isActive);
+    // const triggerElement = document.getElementById(this.args.triggerId);
+    // if (triggerElement?.contains(document.activeElement))  {
+    //   console.log('skipping _open, triggerElement contains activeElement');
+    //   return;
+    // }
     if (!this.storedAPI.isOpen) {
       this.storedAPI.actions.open(event);
     }
@@ -311,6 +312,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     console.log('target gaining focus', event.target);
     console.log('target losing focus', event.relatedTarget);
     console.log('activeElement', document.activeElement);
+    console.log('isActive', this.storedAPI.isActive);
     if (!this.isDestroying) {
       console.log('called handleFocus, destroy schedule block');
       scheduleOnce('actions', this, this._updateIsActive, true);
@@ -323,8 +325,11 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
 
   @action
   handleBlur(event: FocusEvent): void {
+    console.groupCollapsed('called handleBlur');
     if (!this.isDestroying) {
-      console.log('called handleBlur, destroy schedule block');
+      console.log('destroy schedule block');
+      console.log('isActive', this.storedAPI.isActive);
+      console.groupEnd()
 
       scheduleOnce('actions', this, this._updateIsActive, false);
     }

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -289,6 +289,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
 
   @action
   _open(event: FocusEvent): void {
+    console.log('called _open');
     if (!this.storedAPI.isOpen) {
       this.storedAPI.actions.open(event);
     }
@@ -297,7 +298,9 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
 
   @action
   handleFocus(event: FocusEvent): void {
+    console.log('called handleFocus');
     if (!this.isDestroying) {
+      console.log('called handleFocus, destroy schedule block');
       scheduleOnce('actions', this, this._updateIsActive, true);
     }
     if (this.args.onFocus) {
@@ -308,6 +311,8 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   @action
   handleBlur(event: FocusEvent): void {
     if (!this.isDestroying) {
+      console.log('called handleBlur, destroy schedule block');
+
       scheduleOnce('actions', this, this._updateIsActive, false);
     }
     if (this.args.onBlur) {
@@ -516,10 +521,12 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   }
 
   _handleKeyTab(select: Select, e: KeyboardEvent): void {
+    console.log('called handleKeyTab, closing dropdown');
     select.actions.close(e);
   }
 
   _handleKeyESC(select: Select, e: KeyboardEvent): void {
+    console.log('called handleKeyESC, closing dropdown now');
     select.actions.close(e);
   }
 

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -269,12 +269,6 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   }
 
   @action
-  onFocusTrigger(e: FocusEvent) : void {
-    console.log('onFocusTrigger was called', this.args.triggerId);
-    console.log('event', e);
-  }
-
-  @action
   handleTriggerKeydown(e: KeyboardEvent) {
     if (this.args.onKeydown && this.args.onKeydown(this.storedAPI, e) === false) {
       e.stopImmediatePropagation();
@@ -301,6 +295,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (this.args.onFocus) {
       this.args.onFocus(this.storedAPI, event);
     }
+    this.storedAPI.actions.open(e);
     console.log('handleFocus was called', this.args.triggerId);
   }
 

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -269,6 +269,12 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   }
 
   @action
+  onFocusTrigger(dropdown: Component, e: FocusEvent) : void {
+    console.log('dropdown', dropdown);
+    console.log('event', e);
+  }
+
+  @action
   handleTriggerKeydown(e: KeyboardEvent) {
     if (this.args.onKeydown && this.args.onKeydown(this.storedAPI, e) === false) {
       e.stopImmediatePropagation();

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -288,6 +288,14 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   }
 
   @action
+  _open(event: FocusEvent): void {
+    if (!this.storedAPI.isOpen) {
+      this.storedAPI.actions.open(event);
+    }
+    console.log('called _open');
+  }
+
+  @action
   handleFocus(event: FocusEvent): void {
     if (!this.isDestroying) {
       scheduleOnce('actions', this, this._updateIsActive, true);
@@ -295,8 +303,6 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (this.args.onFocus) {
       this.args.onFocus(this.storedAPI, event);
     }
-    this.storedAPI.actions.open(event);
-    console.log('handleFocus was called', this.args.triggerId);
   }
 
   @action

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -286,25 +286,6 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
       return this._routeKeydown(this.storedAPI, e);
     }
   }
-
-  @action
-  handleMousedown() : void {
-    const trigger = document.getElementById(this.args.triggerId);
-    trigger?.setAttribute('mousedown', 'true');
-  }
-
-  @action
-  _open(event: FocusEvent): void {
-    const trigger = document.getElementById(this.args.triggerId);
-    if (trigger?.getAttribute('mousedown') === 'true') {
-      trigger?.setAttribute('mousedown', 'false');
-      return;
-    }
-    if (!this.storedAPI.isOpen) {
-      this.storedAPI.actions.open(event);
-    }
-  }
-
   @action
   handleFocus(event: FocusEvent): void {
     if (!this.isDestroying) {

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -300,51 +300,24 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
       trigger?.setAttribute('mousedown', 'false');
       return;
     }
-    console.groupCollapsed('called _open');
-    console.log('target gaining focuswithin', event.target);
-    console.log('target losing focuswithin', event.relatedTarget);
-    console.log('activeElement', document.activeElement);
-    console.log('isActive', this.storedAPI.isActive);
-    console.log('isLoading', this.storedAPI.loading);
-    // const triggerElement = document.getElementById(this.args.triggerId);
-    // if (triggerElement?.contains(document.activeElement))  {
-    //   console.log('skipping _open, triggerElement contains activeElement');
-    //   return;
-    // }
     if (!this.storedAPI.isOpen) {
       this.storedAPI.actions.open(event);
     }
-    console.groupEnd()
   }
 
   @action
   handleFocus(event: FocusEvent): void {
-    console.groupCollapsed('called handleFocus');
-    console.log('target gaining focus', event.target);
-    console.log('target losing focus', event.relatedTarget);
-    console.log('activeElement', document.activeElement);
-    console.log('isActive', this.storedAPI.isActive);
-    console.log('loading', this.storedAPI.loading);
     if (!this.isDestroying) {
-      console.log('called handleFocus, destroy schedule block');
       scheduleOnce('actions', this, this._updateIsActive, true);
     }
     if (this.args.onFocus) {
       this.args.onFocus(this.storedAPI, event);
     }
-    console.groupEnd();
   }
 
   @action
   handleBlur(event: FocusEvent): void {
-    console.groupCollapsed('called handleBlur');
-    console.log('target gaining focus', event.relatedTarget);
-    console.log('target losing focus', event.target);
     if (!this.isDestroying) {
-      console.log('destroy schedule block');
-      console.log('isActive', this.storedAPI.isActive);
-      console.groupEnd()
-
       scheduleOnce('actions', this, this._updateIsActive, false);
     }
     if (this.args.onBlur) {
@@ -553,12 +526,10 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   }
 
   _handleKeyTab(select: Select, e: KeyboardEvent): void {
-    console.log('called handleKeyTab, closing dropdown');
     select.actions.close(e);
   }
 
   _handleKeyESC(select: Select, e: KeyboardEvent): void {
-    console.log('called handleKeyESC, closing dropdown now');
     select.actions.close(e);
   }
 

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -290,21 +290,26 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   @action
   _open(event: FocusEvent): void {
     debugger;
+    console.groupCollapsed('called _open');
+    console.log('target gaining focuswithin', event.target);
+    console.log('target losing focuswithin', event.relatedTarget);
+    console.log('activeElement', document.activeElement);
     const triggerElement = document.getElementById(this.args.triggerId);
     if (triggerElement?.contains(document.activeElement))  {
       console.log('skipping _open, triggerElement contains activeElement');
       return;
     }
-    console.log('called _open');
     if (!this.storedAPI.isOpen) {
       this.storedAPI.actions.open(event);
     }
-    console.log('called _open');
+    console.groupEnd()
   }
 
   @action
   handleFocus(event: FocusEvent): void {
-    console.log('called handleFocus');
+    console.groupCollapsed('called handleFocus');
+    console.log('target gaining focus', event.target);
+    console.log('target losing focus', event.relatedTarget);
     if (!this.isDestroying) {
       console.log('called handleFocus, destroy schedule block');
       scheduleOnce('actions', this, this._updateIsActive, true);
@@ -312,6 +317,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (this.args.onFocus) {
       this.args.onFocus(this.storedAPI, event);
     }
+    console.groupEnd();
   }
 
   @action

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -288,8 +288,18 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   }
 
   @action
+  handleMousedown() : void {
+    const trigger = document.getElementById(this.args.triggerId);
+    trigger?.setAttribute('mousedown', 'true');
+  }
+
+  @action
   _open(event: FocusEvent): void {
-    debugger;
+    const trigger = document.getElementById(this.args.triggerId);
+    if (trigger?.getAttribute('mousedown') === 'true') {
+      trigger?.setAttribute('mousedown', 'false');
+      return;
+    }
     console.groupCollapsed('called _open');
     console.log('target gaining focuswithin', event.target);
     console.log('target losing focuswithin', event.relatedTarget);

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -295,6 +295,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     console.log('target losing focuswithin', event.relatedTarget);
     console.log('activeElement', document.activeElement);
     console.log('isActive', this.storedAPI.isActive);
+    console.log('isLoading', this.storedAPI.loading);
     // const triggerElement = document.getElementById(this.args.triggerId);
     // if (triggerElement?.contains(document.activeElement))  {
     //   console.log('skipping _open, triggerElement contains activeElement');
@@ -313,6 +314,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     console.log('target losing focus', event.relatedTarget);
     console.log('activeElement', document.activeElement);
     console.log('isActive', this.storedAPI.isActive);
+    console.log('loading', this.storedAPI.loading);
     if (!this.isDestroying) {
       console.log('called handleFocus, destroy schedule block');
       scheduleOnce('actions', this, this._updateIsActive, true);
@@ -326,6 +328,8 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   @action
   handleBlur(event: FocusEvent): void {
     console.groupCollapsed('called handleBlur');
+    console.log('target gaining focus', event.relatedTarget);
+    console.log('target losing focus', event.target);
     if (!this.isDestroying) {
       console.log('destroy schedule block');
       console.log('isActive', this.storedAPI.isActive);

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -295,7 +295,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (this.args.onFocus) {
       this.args.onFocus(this.storedAPI, event);
     }
-    this.storedAPI.actions.open(e);
+    this.storedAPI.actions.open(event);
     console.log('handleFocus was called', this.args.triggerId);
   }
 

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -289,7 +289,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
 
   @action
   _open(event: FocusEvent): void {
-    console.log('_open isActive', this.storedAPI.isActive);
+    debugger;
     const triggerElement = document.getElementById(this.args.triggerId);
     if (triggerElement?.contains(document.activeElement))  {
       console.log('skipping _open, triggerElement contains activeElement');

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -289,6 +289,12 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
 
   @action
   _open(event: FocusEvent): void {
+    console.log('_open isActive', this.storedAPI.isActive);
+    const triggerElement = document.getElementById(this.args.triggerId);
+    if (triggerElement?.contains(document.activeElement))  {
+      console.log('skipping _open, triggerElement contains activeElement');
+      return;
+    }
     console.log('called _open');
     if (!this.storedAPI.isOpen) {
       this.storedAPI.actions.open(event);

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -269,8 +269,8 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
   }
 
   @action
-  onFocusTrigger(dropdown: Component, e: FocusEvent) : void {
-    console.log('dropdown', dropdown);
+  onFocusTrigger(e: FocusEvent) : void {
+    console.log('onFocusTrigger was called', this.args.triggerId);
     console.log('event', e);
   }
 
@@ -301,6 +301,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     if (this.args.onFocus) {
       this.args.onFocus(this.storedAPI, event);
     }
+    console.log('handleFocus was called', this.args.triggerId);
   }
 
   @action

--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -310,6 +310,7 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
     console.groupCollapsed('called handleFocus');
     console.log('target gaining focus', event.target);
     console.log('target losing focus', event.relatedTarget);
+    console.log('activeElement', document.activeElement);
     if (!this.isDestroying) {
       console.log('called handleFocus, destroy schedule block');
       scheduleOnce('actions', this, this._updateIsActive, true);

--- a/addon/components/power-select/before-options.hbs
+++ b/addon/components/power-select/before-options.hbs
@@ -8,6 +8,8 @@
       class="ember-power-select-search-input"
       value={{@select.searchText}}
       aria-activedescendant={{@ariaActiveDescendant}}
+      aria-autocomplete="list"
+      aria-expanded="{{if @select.isOpen 'true' 'false'}}"
       aria-controls={{@listboxId}}
       aria-haspopup="listbox"
       placeholder={{@searchPlaceholder}}

--- a/addon/components/power-select/before-options.ts
+++ b/addon/components/power-select/before-options.ts
@@ -21,6 +21,7 @@ export default class BeforeOptions extends Component<Args> {
       return false;
     }
     if (e.keyCode === 13) {
+      console.log('called handleKeydown in beforeOptions, closing dropdown', e.key,);
       this.args.select.actions.close(e);
     }
   }

--- a/addon/components/power-select/before-options.ts
+++ b/addon/components/power-select/before-options.ts
@@ -21,7 +21,6 @@ export default class BeforeOptions extends Component<Args> {
       return false;
     }
     if (e.keyCode === 13) {
-      console.log('called handleKeydown in beforeOptions, closing dropdown', e.key,);
       this.args.select.actions.close(e);
     }
   }

--- a/addon/components/power-select/no-matches-message.hbs
+++ b/addon/components/power-select/no-matches-message.hbs
@@ -1,6 +1,6 @@
 {{#if @noMatchesMessage}}
   <ul class="ember-power-select-options" role="listbox" aria-label={{@ariaLabel}} aria-labelledby={{@ariaLabelledBy}}>
-    <li class="ember-power-select-option ember-power-select-option--no-matches-message" role="option" aria-selected={{false}}>
+    <li class="ember-power-select-option ember-power-select-option--no-matches-message" role="option" aria-selected="false">
       {{@noMatchesMessage}}
     </li>
   </ul>

--- a/addon/components/power-select/no-matches-message.hbs
+++ b/addon/components/power-select/no-matches-message.hbs
@@ -1,5 +1,5 @@
 {{#if @noMatchesMessage}}
-  <ul class="ember-power-select-options" role="listbox">
+  <ul class="ember-power-select-options" role="listbox" aria-label={{@ariaLabel}} aria-labelledby={{@ariaLabelledBy}}>
     <li class="ember-power-select-option ember-power-select-option--no-matches-message" role="option" aria-selected={{false}}>
       {{@noMatchesMessage}}
     </li>

--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -30,7 +30,7 @@
       {{else}}
         <li class="ember-power-select-option"
           id="{{@select.uniqueId}}-{{@groupIndex}}{{index}}"
-          aria-selected="{{ember-power-select-is-selected opt @select.selected}}"
+          aria-selected={{ember-power-select-is-selected opt @select.selected}}
           aria-disabled={{if opt.disabled "true"}}
           aria-current="{{eq opt @select.highlighted}}"
           data-option-index="{{@groupIndex}}{{index}}"

--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -7,9 +7,9 @@
       <li class="ember-power-select-option ember-power-select-option--loading-message" role="option" aria-selected="false">{{@loadingMessage}}</li>
     {{/if}}
   {{/if}}
-  {{#let 
-    (component (ensure-safe-component @groupComponent)) 
-    (component (ensure-safe-component @optionsComponent)) 
+  {{#let
+    (component (ensure-safe-component @groupComponent))
+    (component (ensure-safe-component @optionsComponent))
   as |Group Options|}}
     {{#each @options as |opt index|}}
       {{#if (ember-power-select-is-group opt)}}
@@ -22,6 +22,7 @@
             @groupComponent={{@groupComponent}}
             @extra={{@extra}}
             role="group"
+            @ariaSelected={{@ariaSelected}}
             class="ember-power-select-options" as |option|>
             {{yield option @select}}
           </Options>

--- a/addon/components/power-select/options.hbs
+++ b/addon/components/power-select/options.hbs
@@ -1,7 +1,10 @@
-<ul role="listbox" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}} ...attributes>
+<ul role="listbox" {{did-insert this.addHandlers}} {{will-destroy this.removeHandlers}}
+    aria-label={{@ariaLabel}}
+    aria-labelledby={{@ariaLabelledBy}}
+    ...attributes>
   {{#if @select.loading}}
     {{#if @loadingMessage}}
-      <li class="ember-power-select-option ember-power-select-option--loading-message" role="option" aria-selected={{false}}>{{@loadingMessage}}</li>
+      <li class="ember-power-select-option ember-power-select-option--loading-message" role="option" aria-selected="false">{{@loadingMessage}}</li>
     {{/if}}
   {{/if}}
   {{#let 

--- a/addon/components/power-select/search-message.hbs
+++ b/addon/components/power-select/search-message.hbs
@@ -1,7 +1,7 @@
 <ul class="ember-power-select-options" role="listbox" aria-label={{@ariaLabel}}
     aria-labelledby={{@ariaLabelledBy}}
     ...attributes>
-  <li class="ember-power-select-option ember-power-select-option--search-message" role="option" aria-selected={{false}}>
+  <li class="ember-power-select-option ember-power-select-option--search-message" role="option" aria-selected="false">
     {{@searchMessage}}
   </li>
 </ul>

--- a/addon/components/power-select/search-message.hbs
+++ b/addon/components/power-select/search-message.hbs
@@ -1,4 +1,6 @@
-<ul class="ember-power-select-options" role="listbox" ...attributes>
+<ul class="ember-power-select-options" role="listbox" aria-label={{@ariaLabel}}
+    aria-labelledby={{@ariaLabelledBy}}
+    ...attributes>
   <li class="ember-power-select-option ember-power-select-option--search-message" role="option" aria-selected={{false}}>
     {{@searchMessage}}
   </li>

--- a/addon/helpers/ember-power-select-is-selected.ts
+++ b/addon/helpers/ember-power-select-is-selected.ts
@@ -5,17 +5,17 @@ import { isEqual } from '@ember/utils';
 // TODO: Make it private or scoped to the component
 export function emberPowerSelectIsSelected([option, selected]: [any, any]/* , hash*/): boolean {
   if (selected === undefined || selected === null) {
-    return false;
+    return "false";
   }
   if (isEmberArray(selected)) {
     for (let i = 0; i < selected.length; i++) {
       if (isEqual(selected[i], option)) {
-        return true;
+        return "true";
       }
     }
-    return false;
+    return "false";
   } else {
-    return isEqual(option, selected);
+    return `${isEqual(option, selected)};`
   }
 }
 

--- a/addon/helpers/ember-power-select-is-selected.ts
+++ b/addon/helpers/ember-power-select-is-selected.ts
@@ -15,7 +15,7 @@ export function emberPowerSelectIsSelected([option, selected]: [any, any]/* , ha
     }
     return "false";
   } else {
-    return `${isEqual(option, selected)};`
+    return `${isEqual(option, selected)}`;
   }
 }
 


### PR DESCRIPTION
1. Pass along ariaLabel and ariaLabelledBy 
2. The QzSelect now opens when it receives focus through tabbing too, that way the user doesn't have to press enter in order to type, and they will immediately be able to tell that their input is needed. The audit requested the combobox (the input field) be present by default, this is one step in the right direction (unfortunately showing the input by default isn't possible). 
3. Ensure ariaSelected is set correctly for the selected option.